### PR TITLE
specify byte encoding for messages

### DIFF
--- a/src/main/scala/KafkaProducer.scala
+++ b/src/main/scala/KafkaProducer.scala
@@ -95,7 +95,7 @@ case class KafkaProducer(
 
   def sendString(message: String) = {
     try {
-      producer.send(new KeyedMessage(topic,message.getBytes))
+      producer.send(new KeyedMessage(topic,message.getBytes("UTF8")))
     } catch {
       case e: Exception =>
         e.printStackTrace


### PR DESCRIPTION
Using String#getBytes without specifying the encoding will use the system default.  Since this might change (maybe unexpectedly) we'll be explicit about the encoding.
