### PR TITLE
Wrong args for KeyedMessage constructor

### DIFF
--- a/src/main/scala/KafkaProducer.scala
+++ b/src/main/scala/KafkaProducer.scala
@@ -97,7 +97,7 @@ case class KafkaProducer(
      if (partition == null) {
        new KeyedMessage(topic,message)
      } else {
-       new KeyedMessage(topic,message, partition)
+       new KeyedMessage(topic,partition,message)
      }
   }
   


### PR DESCRIPTION
Please check the following code from kafka repo
https://github.com/apache/kafka/blob/0.8.1/core/src/main/scala/kafka/producer/KeyedMessage.scala
the constructor of KeyedMessage takes topic,message or topic,key,message as arguments
