### PR TITLE
Fix bug causing random partitions with partition key

### DIFF
--- a/src/main/scala/KafkaProducer.scala
+++ b/src/main/scala/KafkaProducer.scala
@@ -93,7 +93,7 @@ case class KafkaProducer(
 
   val producer = new Producer[AnyRef, AnyRef](new ProducerConfig(props))
   
-  def kafkaMesssage(message: Array[Byte], partition: Array[Byte]): KeyedMessage[AnyRef, AnyRef] = {
+  def kafkaMesssage(message: List[Byte], partition: List[Byte]): KeyedMessage[AnyRef, AnyRef] = {
      if (partition == null) {
        new KeyedMessage(topic,message)
      } else {
@@ -101,9 +101,9 @@ case class KafkaProducer(
      }
   }
   
-  def send(message: String, partition: String = null): Unit = send(message.getBytes("UTF8"), if (partition == null) null else partition.getBytes("UTF8"))
+  def send(message: String, partition: String = null): Unit = send(message.getBytes("UTF8").toList, if (partition == null) null else partition.getBytes("UTF8").toList)
 
-  def send(message: Array[Byte], partition: Array[Byte]): Unit = {
+  def send(message: List[Byte], partition: List[Byte]): Unit = {
     try {
       producer.send(kafkaMesssage(message, partition))
     } catch {


### PR DESCRIPTION
Fixes #22

Array[Byte] does not have the identical hashcode even given identical contents. List[Byte] has the desired hashcode property at the cost of some performance.
